### PR TITLE
Feedback Items

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -8325,6 +8325,7 @@ nav.toolbar .tool .darktool .dijitTitlePaneTitleHover   {
 }
 
 .modal-loading {
+  z-index: 999;
   display: block;
   position: absolute;
   width: 100vw;
@@ -8373,11 +8374,18 @@ nav.toolbar .tool .darktool .dijitTitlePaneTitleHover   {
   grid-column: 1;
   grid-row: row-start 1 / 4;
   align-self: center;
+  display: flex;
+  flex-direction: column;
 }
 
 .blade_image img {
   width: 10vh;
   height: 10vh;
+}
+
+.blade_image span {
+  color: black;
+  font-size: 12px;
 }
 
 .blade_slider {

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -96,7 +96,7 @@ require([
 
     map = new Map("map", {
         center: [center_x, center_y],
-        // zoom: 14,
+        // zoom: 13,
         basemap: "dark-gray",
         slider: true,
         sliderOrientation: "horizontal",
@@ -1272,7 +1272,7 @@ require([
     landuseSymbol.setSize("5");
 
     var landuseRenderer = new UniqueValueRenderer(
-        landuseSymbol,
+        null,
         "LandUseCatExisting"
     );
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Watershed MVP 4.0
+# Watershed MVP 4.1
 
 > The Cape Cod Commission developed the WatershedMVP application for professionals, municipal officials and community members in order to assist in creating the most cost-effective and efficient solutions to Cape Cod’s wastewater problem. The application is an informational resource intended to provide regional estimates for planning purposes. WatershedMVP is an initiative of the Cape Cod Commission’s Strategic Information Office (SIO). 
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,8 +8,8 @@
             <button class="close-button" id ="closeButton">
                 <i class="fa fa-times"></i>
             </button>
-            <img class = 'login-image' src = 'https://user-images.githubusercontent.com/16725828/70354678-3e457600-183e-11ea-8a95-6baf544ec121.jpg'/>
-            <h2 class="section-title">Welcome to the new and improved WatershedMVP 4.0!</h2>
+            <!-- <img class = 'login-image' src = 'https://user-images.githubusercontent.com/16725828/70354678-3e457600-183e-11ea-8a95-6baf544ec121.jpg'/> -->
+            <h2 class="section-title">Welcome to the new and improved WatershedMVP 4.1!</h2>
             <p>The Cape Cod Commission developed the WatershedMVP application for professionals, municipal officials and community members in order to assist in creating the most cost-effective and efficient solutions to Cape Cod’s wastewater problem.</p>
 
             <p>The application is an informational resource intended to provide regional estimates for planning purposes. WatershedMVP is an initiative of the Cape Cod Commission’s Strategic Information Office (SIO). To learn more about the WatershedMVP application and the Cape Cod Commission and its SIO, please <a href="http://www.capecodcommission.org/index.php?id=205" target="_blank">contact us</a>.</p>

--- a/resources/views/common/map-tools.blade.php
+++ b/resources/views/common/map-tools.blade.php
@@ -14,10 +14,10 @@
 		</div>
 		<div id="basemaps-wrapper" class="leaflet-bar"></div>
 	</div>
-	<label id = 'mapLayersIcon' class="darktool">
+	<label id = 'mapLayersIcon' class="darktool"  title="Layers">
 		<i class="fa fa-globe fa-globe-white fa-2x js-menu-trigger sliding-panel-button"></i>
 	</label>
-	<label class="darktool">
+	<label class="darktool" title="Labels on/off">
 		<i id='disable-popups' class="fa fa-eye fa-eye-white fa-2x js-menu-trigger enabled"></i>
 	</label>
 	

--- a/resources/views/common/navigation.blade.php
+++ b/resources/views/common/navigation.blade.php
@@ -1,6 +1,6 @@
 <nav>
     <ul>
-        <li class="left"><img src="https://www.watershedmvp.org/images/mvplogo.png" alt="WatershedMVP 4.0 by Cape Cod Commission"></li>
+        <li class="left"><img src="{{$_ENV['CCC_ICONS_PNG']}}mvplogo.png" alt="WatershedMVP 4.1 by Cape Cod Commission"></li>
         <li class="right"><a href="{{url('/help')}}" class="button"><i class="fa fa-btn fa-question-circle"></i> Help</a></li>
         @if (Auth::guest())
             <li class="right"><a href="{{ url('/register') }}" class="button"><i class="fa fa-btn fa-user-plus"></i> Register</a></li>

--- a/resources/views/common/technology-collect-move-edit.blade.php
+++ b/resources/views/common/technology-collect-move-edit.blade.php
@@ -12,9 +12,10 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Update the amount to be treated.">
-			<button title="Update geometry" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Update Collection</button>
+			<button title="Edit Polygon" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Edit Polygon</button>
 			<button v-show="{{$dumpTreatment->TreatmentID}} > 0" title="Update Move Site" class="blade_button" id="edit_geometry" data-treatment="{{$dumpTreatment->TreatmentID}}">Update Move Site</button>
 			<label id = "collect-label-reduc">Update the valid reduction rate between {{$tech->Nutri_Reduc_N_Low_ppm}} and {{$tech->Nutri_Reduc_N_High_ppm}} ppm.</label>
 			<input type="range" id="collect-rate" min="{{$tech->Nutri_Reduc_N_Low_ppm}}" max="{{$tech->Nutri_Reduc_N_High_ppm}}" v-model="collect_rate" value="{{$treatment->Treatment_Value}}" step="1">
@@ -40,11 +41,17 @@
 			let setUpdateTreatmentButtonStyling = updateTreatmentButton.setAttribute("style", "display:none;");
 			let treatmentValue = $('#collect-rate').val();
 			let url = "{{url('/update', $treatment->TreatmentID)}}"  + '/' + treatmentValue;
+
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(msg){
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				resetGraphicPropsAfterUpdate(msg);
 				$( "#update" ).trigger( "click" );

--- a/resources/views/common/technology-collect-move.blade.php
+++ b/resources/views/common/technology-collect-move.blade.php
@@ -12,10 +12,11 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Select the amount to be treated.">
 			<button title="Draw Collection" class="blade_button" id="draw_collection">Draw Collection</button>
-			<button title="Select Move Site" class="blade_button" id="select_area" style="display:none;">Select Move Site</button>
+			<button title="Select New Disposal Site" class="blade_button" id="select_area" style="display:none;">Select New Disposal Site</button>
 			<label id = "collect-label-reduc" style="display:none;">Select a valid reduction rate between {{$tech->Nutri_Reduc_N_Low_ppm}} and {{$tech->Nutri_Reduc_N_High_ppm}} ppm.</label>
 			<input type="range" id="collect-rate" min="{{$tech->Nutri_Reduc_N_Low_ppm}}" max="{{$tech->Nutri_Reduc_N_High_ppm}}" v-model="collect_rate" value="{{$tech->Nutri_Reduc_N_Default_ppm}}" step="1" style="display:none;">
 			<label id = "collect-label-rate" style="display:none;">@{{collect_rate}} ppm</label>
@@ -71,11 +72,17 @@
 			let setApplyTreatmentButtonStyling = applyTreatmentButton.setAttribute("style", "display:none;");
 			let rate = $('#collect-rate').val();
 			let url = "{{url('/apply_collectStay')}}" + '/' + rate + '/' + techId;
+
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(treatment_id){
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				$( "#update" ).trigger( "click" );
 				addTreatmentIdToGraphic(treatment_id);

--- a/resources/views/common/technology-collect-stay-edit.blade.php
+++ b/resources/views/common/technology-collect-stay-edit.blade.php
@@ -9,10 +9,11 @@
 		</button>
 		<h4 class="blade_title" title="{{$tech->technology_strategy}}">
 			{{$tech->technology_strategy}}
-			<button title="Update geometry" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Update Geometry</button>
+			<button title="Edit Polygon" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Edit Polygon</button>
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}"> 
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Update the amount to be treated.">
 			<label v-if = "{{in_array($tech->technology_type,['Innovative and Resource-Management Technologies']) && $tech->unit_metric=='Linear Foot'}}" id="unit_metric_label">Enter length (Linear Feet) of PRB to be treated:</label>
@@ -43,11 +44,17 @@
 			let treatmentValue = $('#collect-rate').val();
 			let linearFeet = $('#unit_metric').val() || null;
 			let url = "{{url('/update', $treatment->TreatmentID)}}"  + '/' + treatmentValue  + '/' + linearFeet;
+
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(msg){
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				resetGraphicPropsAfterUpdate(msg);
 				$( "#update" ).trigger( "click" );

--- a/resources/views/common/technology-collect-stay.blade.php
+++ b/resources/views/common/technology-collect-stay.blade.php
@@ -12,6 +12,7 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">  
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Select the amount to be treated.">
 			<button title="Draw Treatment" class="blade_button" id="draw_collection">Draw Collection</button>
@@ -63,11 +64,17 @@
 			let rate = $('#collect-rate').val();
 			let linearFeet = $('#unit_metric').val() || null;
 			let url = "{{url('/apply_collectStay')}}" + '/' + rate + '/' + techId + '/' + linearFeet;
+
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(treatment_id){
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				$( "#update" ).trigger( "click" );
 				addTreatmentIdToGraphic(treatment_id);

--- a/resources/views/common/technology-groundwater-edit.blade.php
+++ b/resources/views/common/technology-groundwater-edit.blade.php
@@ -17,8 +17,9 @@
 	<section class="body">
 <p>{{$treatment->Treatment_Class}}</p>
 			<div class="technology">
-				<a href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->id}}" target="_blank">
+				<a href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->id}}" target="_blank" class="blade_image">
 					<img src="https://www.cch2o.org/Matrix/icons/{{$treatment->treatment_icon}}" width="75">
+					<span>Click icon for more info.</span>
 				 {{$tech->Technology_Strategy}}&nbsp;<i class="fa fa-question-circle"></i>
 				</a>			
 			</div>
@@ -76,7 +77,7 @@
 				<input type="range" id="ground-percent" min="{{$tech->Nutri_Reduc_N_Low}}" max="{{$tech->Nutri_Reduc_N_High}}" v-model="ground_percent" value="{{$treatment->Treatment_Value}}" style="display:inline;"> @{{ground_percent}}%
 			</p>
 			<p>
-				<button title="Update geometry" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Update Geometry</button>
+				<button title="Edit Polygon" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Edit Polygon</button>
 				<button id="updatetreatment">Update</button>
 				<button id="deletetreatment" class='button--cta right'><i class="fa fa-trash-o"></i> Delete</button>
 			</p>
@@ -142,11 +143,17 @@
 					e.preventDefault();
 					var rate = $('#ground-percent').val();
 					var url = "{{url('/update', $treatment->TreatmentID)}}"  + '/' + rate;
+
+					destroyModalContents();
+					$(".modal-loading").toggle();
+					$('.modal-wrapper').toggle();
+
 					$.ajax({
 						method: 'GET',
 						url: url
 					})
 						.done(function(msg){
+							$(".modal-loading").toggle();
 							destroyModalContents();
 							resetGraphicPropsAfterUpdate(msg);
 							$( "#update" ).trigger( "click" );

--- a/resources/views/common/technology-groundwater.blade.php
+++ b/resources/views/common/technology-groundwater.blade.php
@@ -14,8 +14,9 @@
 	<section class="body">
 
 			<div class="technology">
-				<a href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->id}}" target="_blank">
+				<a href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->id}}" target="_blank" class="blade_image">
 					<img src="https://www.watershedmvp.org/images/SVG/{{$tech->Icon}}" width="75">
+					<span>Click icon for more info.</span>
 				 {{$tech->Technology_Strategy}}&nbsp;<i class="fa fa-question-circle"></i>
 				</a>			
 			</div>

--- a/resources/views/common/technology-in-embayment-edit.blade.php
+++ b/resources/views/common/technology-in-embayment-edit.blade.php
@@ -12,6 +12,7 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">  
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Select the amount to be treated.">
 			<button title="Change Selected Subembayment" class="blade_button" id="select_area">Change Subembayment</button>
@@ -71,11 +72,17 @@
 			let rate = $('#subembayment-rate').val();
 			let units = $('#unit_metric').val();
 			let url = "{{url('/update', $treatment->TreatmentID)}}"  + '/' + rate + '/' + units;
+
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(treatment_id){
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				resetGraphicPropsAfterUpdate(treatment_id);
 				$( "#update" ).trigger( "click" );

--- a/resources/views/common/technology-in-embayment.blade.php
+++ b/resources/views/common/technology-in-embayment.blade.php
@@ -12,6 +12,7 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">  
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Select the amount to be treated.">
 			<button title="Select Subembayment" class="blade_button" id="select_area">Select Subembayment</button>
@@ -57,11 +58,17 @@
 			let rate = $('#subembayment-rate').val();
 			let units = $('#unit_metric').val();
 			let url = "{{url('apply_embayment')}}" + '/' + rate + '/' + units + '/' + techId;
+
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(treatment_id){
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				$( "#update" ).trigger( "click" );
 				addTreatmentIdToGraphic(treatment_id);

--- a/resources/views/common/technology-management-edit.blade.php
+++ b/resources/views/common/technology-management-edit.blade.php
@@ -12,6 +12,7 @@
     </h4>
     <a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 		<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">  
+        <span>Click icon for more info.</span>
     </a>
     <div class="blade_slider" title="Enter a valid reduction rate between {{$tech->Nutri_Reduc_N_Low}} and {{$tech->Nutri_Reduc_N_High}} percent.">
         <label>Nutrient Reduction Rate</label>
@@ -43,6 +44,11 @@
             if ("{{$tech->technology_id == 400}}") {
                 let treatmentValue = $('#fert-percent').val();
                 let url = "{{url('/update', $treatment->TreatmentID)}}" + '/' + treatmentValue;
+
+                destroyModalContents();
+                $(".modal-loading").toggle();
+                $('.modal-wrapper').toggle();
+
                 $.ajax({
                     method: 'GET',
                     url: url
@@ -50,6 +56,7 @@
                 // Once the GET method is complete, hide the modal, update the subembayments and embayment progresses,
                 // set the newtreatment variable and add it to the treatment stack using the popdown generator
                 .done(function(msg) {
+                    $(".modal-loading").toggle();
                     destroyModalContents();
                     $( "#update" ).trigger( "click" );
                 });
@@ -57,6 +64,10 @@
             else {
                 let treatmentValue = $('#storm-percent').val();
                 let url = "{{url('/update', $treatment->TreatmentID)}}" + '/' + treatmentValue;
+                destroyModalContents();
+                $(".modal-loading").toggle();
+                $('.modal-wrapper').toggle();
+
                 $.ajax({
                     method: 'GET',
                     url: url
@@ -64,6 +75,7 @@
                 // Once the GET method is complete, hide the modal, update the subembayments and embayment progresses,
                 // set the newtreatment variable and add it to the treatment stack using the popdown generator
                 .done(function(msg) {
+                    $(".modal-loading").toggle();
                     destroyModalContents();
                     $( "#update" ).trigger( "click" );
                 });

--- a/resources/views/common/technology-management.blade.php
+++ b/resources/views/common/technology-management.blade.php
@@ -9,8 +9,9 @@
 	</h4>
 	<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 		<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">
+		<span>Click icon for more info.</span>
 	</a>
-	<div class="blade_slider" title="Enter a valid JAY reduction rate between {{$tech->Nutri_Reduc_N_Low}} and {{$tech->Nutri_Reduc_N_High}} percent.">
+	<div class="blade_slider" title="Enter a valid reduction rate between {{$tech->Nutri_Reduc_N_Low}} and {{$tech->Nutri_Reduc_N_High}} percent.">
 		<label>Nutrient Reduction Rate</label>
 		<label v-if="{{$tech->technology_id == 400}}">@{{fert_percent}}%</label>
 		<label v-else="{{$tech->technology_id == 401}}">@{{storm_percent}}%</label>
@@ -39,10 +40,15 @@
 			let applyTreatmentButton = document.getElementById("applytreatment");
 			let setapplyTreatmentButtonStyling = applyTreatmentButton.setAttribute("style", "display:none;");
 			e.preventDefault();
+
 			setapplyTreatmentButtonStyling;
 			if ("{{$tech->technology_id == 400}}") {
 				let percent = $('#fert-percent').val();
 				let url = "{{url('/apply_management')}}" + '/' + percent + '/' + techId;
+				destroyModalContents();
+				$(".modal-loading").toggle();
+				$('.modal-wrapper').toggle();
+
 				$.ajax({
 					method: 'GET',
 					url: url
@@ -50,6 +56,7 @@
 				// Once the GET method is complete, hide the modal, update the subembayments and embayment progresses,
 				// set the newtreatment variable and add it to the treatment stack using the popdown generator
 				.done(function(treatment_id) {
+					$(".modal-loading").toggle();
 					destroyModalContents();
 					$( "#update" ).trigger( "click" );
 					addToStack(treatment_id, '{{$tech->icon}}');
@@ -59,6 +66,10 @@
 			else {
 				let percent = $('#storm-percent').val();
 				let url = "{{url('/apply_management')}}" + '/' + percent + '/' + techId;
+				destroyModalContents();
+				$(".modal-loading").toggle();
+				$('.modal-wrapper').toggle();
+
 				$.ajax({
 					method: 'GET',
 					url: url
@@ -66,6 +77,7 @@
 				// Once the GET method is complete, hide the modal, update the subembayments and embayment progresses,
 				// set the newtreatment variable and add it to the treatment stack using the popdown generator
 				.done(function(treatment_id) {
+					$(".modal-loading").toggle();
 					destroyModalContents();
 					$( "#update" ).trigger( "click" );
 					addToStack(treatment_id, '{{$tech->icon}}');

--- a/resources/views/common/technology-stormwater-non-management-edit.blade.php
+++ b/resources/views/common/technology-stormwater-non-management-edit.blade.php
@@ -12,11 +12,12 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}"> 
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Update number of {{$tech->unit_metric}} to be treated.">
 			<label title="Update number of {{$tech->unit_metric}} to be treated." id="unit_metric_label">Enter number of {{$tech->unit_metric}} to be treated:</label>
 			<input title="Enter a number of {{$tech->unit_metric}} to be treated." v-model="uMetric" type="number" id="unit_metric" name="unit_metric" value="{{$treatment->Treatment_MetricValue}}">
-			<button title="Update geometry" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Update Geometry</button>
+			<button title="Edit Point" class="blade_button" id="edit_geometry" data-treatment="{{$treatment->TreatmentID}}">Edit Point</button>
 		</div>
 	    <button title="Apply technology updates" data-treatment="{{$treatment->TreatmentID}}" class="blade_button" v-show="{{$treatment->Treatment_MetricValue}} != uMetric" id="updateStormwaterNonManangement">Update</button>
 		<button title="Delete treatment" id="deletetreatment" class="blade_button" data-treatment="{{$treatment->TreatmentID}}" v-show="{{$treatment->Treatment_MetricValue}} == uMetric"><i class="fa fa-trash-o"></i> Delete</button>
@@ -36,11 +37,16 @@
 			let setDeleteTreatmentButtonStyling = updateTreatmentButton.setAttribute("style", "display:none;");
 			let treatmentValue = $('#unit_metric').val();
 			let url = "{{url('/update', $treatment->TreatmentID)}}" + '/' + treatmentValue;
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(msg) {
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				resetGraphicPropsAfterUpdate(msg);
 				$( "#update" ).trigger( "click" );

--- a/resources/views/common/technology-stormwater-non-management.blade.php
+++ b/resources/views/common/technology-stormwater-non-management.blade.php
@@ -9,6 +9,7 @@
 		</h4>
 		<a title="{{$tech->technology_strategy}} - Technology Matrix" class="blade_image" href="http://www.cch2o.org/Matrix/detail.php?treatment={{$tech->TM_ID}}" target="_blank">
 			<img src="{{$_ENV['CCC_ICONS_SVG'].$tech->icon}}">
+			<span>Click icon for more info.</span>
 		</a>
 		<div class="blade_slider" title="Enter number of {{$tech->unit_metric}} to be treated.">
 			<button title="Select Location" class="blade_button" id="select_area">Select Location</button>
@@ -41,11 +42,16 @@
 
 			// Create and trigger API route url from parsed properties
 			var url = "{{url('/apply_storm')}}" + '/' + units + '/' + techId;
+			destroyModalContents();
+			$(".modal-loading").toggle();
+			$('.modal-wrapper').toggle();
+
 			$.ajax({
 				method: 'GET',
 				url: url
 			})
 			.done(function(treatment_id) {
+				$(".modal-loading").toggle();
 				destroyModalContents();
 				$( "#update" ).trigger( "click" );
 				addTreatmentIdToGraphic(treatment_id);

--- a/resources/views/help.blade.php
+++ b/resources/views/help.blade.php
@@ -8,7 +8,7 @@
 				
 
 				<div class="panel-body">
-				   <h2>Welcome to WatershedMVP 4.0</h2>
+				   <h2>Welcome to WatershedMVP 4.1</h2>
 				   <p>The Cape Cod Commission developed the WatershedMVP application for professionals, municipal officials and community members in order to assist in creating the most cost-effective and efficient solutions to Cape Cod’s wastewater problem.</p>
 
             <p>The application is an informational resource intended to provide regional estimates for planning purposes. WatershedMVP is an initiative of the Cape Cod Commission’s Strategic Information Office (SIO). To learn more about the WatershedMVP application and the Cape Cod Commission and its SIO, please <a href="http://www.capecodcommission.org/index.php?id=205" target="_blank">contact us</a>.</p>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>  
-    <title>WatershedMVP 4.0</title>
+    <title>WatershedMVP 4.1</title>
     <?php if( env('APP_ENV') == 'production' ) : ?>
 		<link rel="stylesheet" href="{{secure_url('/css/app.css')}}">
 	<?php else :?>

--- a/resources/views/layouts/start.blade.php
+++ b/resources/views/layouts/start.blade.php
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-    <title>WatershedMVP 4.0</title>
+    <title>WatershedMVP 4.1</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <?php if( env('APP_ENV') == 'production' ) : ?>
     <link rel="stylesheet" href="{{secure_url('/css/app.css')}}">
@@ -25,6 +25,9 @@
         $.ajaxSetup({
             headers: {
                 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+            },
+            error: function(x, status, error) {
+                alert("An error occurred");
             }
         });
         var map;
@@ -60,7 +63,7 @@
                 var spatialReference = new esri.SpatialReference({
                     wkid: 102100
                 });
-                var extent = new esri.geometry.Extent(-7893678, 5069311, -7769404, 5192999, spatialReference);
+                var extent = new esri.geometry.Extent(-7893678, 5099911, -7769404, 5112999, spatialReference);
                 var map = new esri.Map("map", {
                     wrapAround180: true,
                     // infoWindow: popup, 
@@ -338,7 +341,7 @@
 
         <!-- EMBAYMENT SELECTION PANEL -->
         <div class="secondary start">
-            <img src="https://www.watershedmvp.org/images/mvplogo.png" alt="WatershedMVP 4.0 by Cape Cod Commission">
+            <!-- <img src="{{$_ENV['CCC_ICONS_PNG']}}mvplogo.png" alt="WatershedMVP 4.1 by Cape Cod Commission"> -->
 
 
 

--- a/resources/views/layouts/wizard.blade.php
+++ b/resources/views/layouts/wizard.blade.php
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>WatershedMVP 4.0 Wizard</title>
+		<title>WatershedMVP 4.1 Wizard</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<?php if( env('APP_ENV') == 'production' ) : ?>
 			<link rel="stylesheet" href="{{secure_url('/css/app.css')}}">
@@ -43,6 +43,15 @@
 		<script src="{{url('/js/jquery.popdown.js')}}"></script>
 		<script src="{{url('/js/helpers.js')}}"></script>
 		<script type="text/javascript">
+			$.ajaxSetup({
+				headers: {
+					'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+				},
+				error: function(x, status, error) {
+					alert("An error occurred");
+				}
+			});
+
 			$(document).ready(function() {
 				// Remove scrolling from body if routed from login to map
 				$('#app-layout').removeClass('scrollable');


### PR DESCRIPTION
- Display loading indicator when apply button is pressed for all tech modals, for both apply and update.
- Setup a global error catcher to avoid obscuring API calls errors. Display browser alert on error.
- Remove the "other" category in the legend for landuse category and treatment type.
- Correct map extent.
- Fix duplicate logos displayed on some pages.
- Display tooltip on map icons.
- Add text under technology icons for all 12 tech modals.
- Correct logo image and app name references.
- Correct texts.